### PR TITLE
We've added capture of request headers for later assertions.

### DIFF
--- a/src/com/pyruby/stubserver/StubMethod.java
+++ b/src/com/pyruby/stubserver/StubMethod.java
@@ -4,6 +4,8 @@ import javax.servlet.http.HttpServletRequest;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -21,6 +23,7 @@ public class StubMethod {
      * The content of the matched requests body.
      */
     public String body;
+    public Map<String, String> headers;
 
     private StubMethod(String method, String url) {
         this.method = method;
@@ -77,6 +80,12 @@ public class StubMethod {
                 body = "";
                 for (String line = bufferedReader.readLine(); line != null; line = bufferedReader.readLine()) {
                     body += line;
+                }
+                Enumeration headerNames = httpServletRequest.getHeaderNames();
+                headers = new HashMap<String, String>();
+                while(headerNames.hasMoreElements()) {
+                    String headerName = (String)headerNames.nextElement();
+                    headers.put(headerName, httpServletRequest.getHeader(headerName));
                 }
             } catch (IOException e) {
                 throw new RuntimeException(e);

--- a/test/com/pyruby/stubserver/StubServerTest.java
+++ b/test/com/pyruby/stubserver/StubServerTest.java
@@ -34,7 +34,7 @@ public class StubServerTest {
     @Test
     public void start_shouldStartAWebServerOnTheDesignatedPort() throws IOException {
         StubResponse response = makeRequest("", "GET", (String) null);
-        
+
         assertNotNull(response);
     }
 
@@ -87,7 +87,7 @@ public class StubServerTest {
         }
         fail("Should not have met all expectations");
     }
-    
+
     @Test
     public void expect_shouldAcceptAPostRequestWithABodyAndCaptureItForLaterAssertion() throws Exception {
         StubMethod postedRequest = post("/some/posted/json");
@@ -98,6 +98,18 @@ public class StubServerTest {
 
         assertEquals(201, response.responseCode);
         assertEquals(json, postedRequest.body);
+    }
+
+    @Test
+    public void expect_shouldAcceptAPostRequestWithHeadersAndCaptureThemForLaterAssertion() throws Exception {
+        StubMethod postedRequest = post("/some/posted/json");
+        server.expect(postedRequest).thenReturn(201, null, null);
+        String json = "{}";
+
+        StubResponse response = makeRequest("/some/posted/json", "POST", json, "application/checkMe");
+
+        assertEquals(201, response.responseCode);
+        assertEquals("application/checkMe", postedRequest.headers.get("Content-Type"));
     }
 
     @Test


### PR DESCRIPTION
Hi Chris,

We've added capture of request headers to StubServer, so that we can assert on them later. Would you care to pull?

Thanks,
Chris & Sathya
