### PR TITLE
thenReturn() with no body OR content-type

### DIFF
--- a/src/com/pyruby/stubserver/Expectation.java
+++ b/src/com/pyruby/stubserver/Expectation.java
@@ -20,6 +20,7 @@ import java.util.List;
 public class Expectation {
     private static final List<Header> EMPTY_HEADERS = Collections.emptyList();
     private static final byte[] EMPTY_BYTES = new byte[0];
+    private static final String NO_MIME_TYPE =null;
 
     private final StubMethod stubbedMethod;
     private CannedResponse cannedResponse;
@@ -30,12 +31,23 @@ public class Expectation {
     }
 
     /**
+     * Define how the server should respond to an expected request.
+     *
+     * @param statusCode The response status code, e.g. 204
+     */
+    public void thenReturn(int statusCode) {
+        thenReturn(statusCode, NO_MIME_TYPE, EMPTY_BYTES, EMPTY_HEADERS);
+    }
+
+    /**
      * Define how the server should respond to an expected request.  My current use cases don't include specific
      * handling multi-part responses, so I haven't implemented any.
+     * This method is deprecated because it expects a mime type when there is no response - use thenReturn(int statusCode) instead.
      *
      * @param statusCode The response status code, e.g. 200
      * @param mimeType   The content type of the response, e.g. text/html
      */
+    @Deprecated
     public void thenReturn(int statusCode, String mimeType) {
         thenReturn(statusCode, mimeType, EMPTY_BYTES, EMPTY_HEADERS);
     }

--- a/test/com/pyruby/stubserver/StubServerTest.java
+++ b/test/com/pyruby/stubserver/StubServerTest.java
@@ -8,12 +8,14 @@ import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
+import static com.pyruby.stubserver.Header.header;
+import static com.pyruby.stubserver.Header.headers;
 import static com.pyruby.stubserver.StubMethod.*;
-import static com.pyruby.stubserver.Header.*;
 import static org.junit.Assert.*;
-import static org.junit.Assert.assertEquals;
 
 public class StubServerTest {
 
@@ -82,7 +84,7 @@ public class StubServerTest {
 
     @Test
     public void expect_shouldAcceptAGetRequestToAUrlThatMatchesARegEx() throws IOException {
-        server.expect(get("/my/expected/\\d+")).thenReturn(200, "text/plain");
+        server.expect(get("/my/expected/\\d+")).thenReturn(200, "text/plain", "");
 
         makeRequest("/my/expected/2312", "GET");
 
@@ -92,7 +94,7 @@ public class StubServerTest {
     @Test
     public void expect_shouldAcceptAPostRequestWithACollectionOfPostParameters() throws IOException {
         StubMethod expectedPath = post("/my/posted/context");
-        server.expect(expectedPath).thenReturn(201, null);
+        server.expect(expectedPath).thenReturn(201);
         Map<String, String> postParams = new HashMap<String, String>();
         postParams.put("name", "arthur");
         postParams.put("age", "1074");
@@ -186,7 +188,7 @@ public class StubServerTest {
     @Test
     public void expect_shouldAcceptAPostRequestWithABodyAndCaptureItForLaterAssertion() throws Exception {
         StubMethod postedRequest = post("/some/posted/json");
-        server.expect(postedRequest).thenReturn(201, null);
+        server.expect(postedRequest).thenReturn(201);
         String json = "{\"key\":\"value\"}";
 
         TestStubResponse response = makeRequest("/some/posted/json", "POST", json, "application/json");
@@ -198,7 +200,7 @@ public class StubServerTest {
     @Test
     public void expect_shouldAcceptAPostRequestWithHeadersAndCaptureThemForLaterAssertion() throws Exception {
         StubMethod postedRequest = post("/some/posted/json");
-        server.expect(postedRequest).thenReturn(201, null);
+        server.expect(postedRequest).thenReturn(201);
         String json = "{}";
 
         TestStubResponse response = makeRequest("/some/posted/json", "POST", json, "application/checkMe");
@@ -232,6 +234,17 @@ public class StubServerTest {
         makeRequest("/some/resource/id", "DELETE", "Yo Mamma");
 
         server.verify();
+    }
+
+    @Test
+    public void expect_shouldHandleNoContentResponsesWithNoContentType() throws IOException {
+        server.expect(post("/some/resource/id")).thenReturn(204);
+
+        TestStubResponse response = makeRequest("/some/resource/id", "POST", "Inbound content");
+
+        server.verify();
+        assertFalse(response.headerFields.containsKey("Content-Type"));
+        assertEquals(0, response.body.length);
     }
 
     @Test


### PR DESCRIPTION
Added an override of thenReturn which only takes a response code. Useful for 204 responses because you don't have to specify a content type.
