### PR TITLE
Added support for stubs as well as the existing expectations.

### DIFF
--- a/src/main/java/com/pyruby/stubserver/Expectation.java
+++ b/src/main/java/com/pyruby/stubserver/Expectation.java
@@ -100,9 +100,13 @@ public class Expectation {
 
     boolean matches(String target, HttpServletRequest httpServletRequest) {
         if (satisfied) return false;
-        boolean matched = stubbedMethod.matches(target, httpServletRequest);
+        boolean matched = stubMethodMatches(target, httpServletRequest);
         if (matched) satisfied = true;
         return matched;
+    }
+
+    protected boolean stubMethodMatches(String target, HttpServletRequest httpServletRequest) {
+        return stubbedMethod.matches(target, httpServletRequest);
     }
 
     void verify() {

--- a/src/main/java/com/pyruby/stubserver/Stub.java
+++ b/src/main/java/com/pyruby/stubserver/Stub.java
@@ -1,0 +1,19 @@
+package com.pyruby.stubserver;
+
+import javax.servlet.http.HttpServletRequest;
+
+public class Stub extends Expectation {
+    public Stub(StubMethod stubMethod) {
+        super(stubMethod);
+    }
+
+    @Override
+    boolean matches(String target, HttpServletRequest httpServletRequest) {
+        return stubMethodMatches(target, httpServletRequest);
+    }
+
+    @Override
+    void verify() {
+        // Deliberately left blank
+    }
+}

--- a/src/main/java/com/pyruby/stubserver/StubServer.java
+++ b/src/main/java/com/pyruby/stubserver/StubServer.java
@@ -125,6 +125,23 @@ public class StubServer {
     }
 
     /**
+     * Specify the method, i.e. {@link StubMethod#get} including context path you expect your application
+     * to call.  The resulting {@link Expectation} is used to allow you to specify what should happen when
+     * a subsequent request matches the stubbedMethod.
+     *
+     * This is different to expect(StubMethod) in that the StubMethod will match against multiple requests
+     * to the StubServer and will never fail verification.
+     *
+     * @param stubbedMethod {@link StubMethod}
+     * @return {@link Expectation} used to specify what happens when a request matches the stubbedMethod
+     */
+    public Expectation stub(StubMethod stubbedMethod) {
+        Stub stub = new Stub(stubbedMethod);
+        expectations.add(stub);
+        return stub;
+    }
+
+    /**
      * Stops the {@link StubServer}.  This should be in either a finally block, a unit test tear-down, or a class
      * tear-down. Using a class tear-down will make testing run much more quickly, but you will also need to
      * use {@link #clearExpectations()} in your unit-test tear-down after each test.


### PR DESCRIPTION
This adds a stub() equivalent to the existing expect() .
Stubs are different to expectations in two ways; they will never fail verification and they will match with more than one request.
