### PR TITLE
Updated README to contain 'stop' instead of 'close'

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Example test:<br>
      //assertions that Bob has the right values as returned from the external ReST api
      server.verify(); // check that all expectations were called
   } finally {
-     server.close();
+     server.stop();
   }
 ```
 With this approach, it feels more like a unit test, but it allows you to totally black box the system under test.


### PR DESCRIPTION
Hi, we think maybe the readme should have 'stop' rather than 'close' or are we missing something?

Sam
