### PR TITLE
Added negative header expectations

### DIFF
--- a/src/main/java/com/pyruby/stubserver/InverseHeaderExpectation.java
+++ b/src/main/java/com/pyruby/stubserver/InverseHeaderExpectation.java
@@ -1,0 +1,19 @@
+package com.pyruby.stubserver;
+
+public class InverseHeaderExpectation implements HeaderExpectation {
+    private final HeaderExpectation expectation;
+
+    public InverseHeaderExpectation(HeaderExpectation expectation) {
+        this.expectation = expectation;
+    }
+
+    @Override
+    public boolean matches(String actualValue) {
+        return !expectation.matches(actualValue);
+    }
+
+    @Override
+    public String getExpectedValue() {
+        return "not " + expectation.getExpectedValue();
+    }
+}

--- a/src/main/java/com/pyruby/stubserver/LiteralHeaderExpectation.java
+++ b/src/main/java/com/pyruby/stubserver/LiteralHeaderExpectation.java
@@ -1,7 +1,7 @@
 package com.pyruby.stubserver;
 
 public class LiteralHeaderExpectation implements HeaderExpectation {
-    private String expectedValue;
+    private final String expectedValue;
 
     public LiteralHeaderExpectation(String expectedValue) {
         this.expectedValue = expectedValue;
@@ -14,6 +14,6 @@ public class LiteralHeaderExpectation implements HeaderExpectation {
 
     @Override
     public String getExpectedValue() {
-        return expectedValue;
+        return "be " + expectedValue;
     }
 }

--- a/src/main/java/com/pyruby/stubserver/RegexHeaderExpectation.java
+++ b/src/main/java/com/pyruby/stubserver/RegexHeaderExpectation.java
@@ -1,7 +1,7 @@
 package com.pyruby.stubserver;
 
 public class RegexHeaderExpectation implements HeaderExpectation {
-    private String valueRegex;
+    private final String valueRegex;
 
     public RegexHeaderExpectation(String valueRegex){
         this.valueRegex = valueRegex;
@@ -14,6 +14,6 @@ public class RegexHeaderExpectation implements HeaderExpectation {
 
     @Override
     public String getExpectedValue() {
-        return valueRegex;
+        return "match " + valueRegex;
     }
 }

--- a/src/main/java/com/pyruby/stubserver/StubMethod.java
+++ b/src/main/java/com/pyruby/stubserver/StubMethod.java
@@ -148,6 +148,35 @@ public class StubMethod {
     }
 
     /**
+     * Sets an expectation that requests will not be matched if they have a request header that matches
+     * a specified expression. To meet the expectation, the header must not match.
+     *
+     * @param key        the name of the header, e.g. "Content-Type". Note that this is canse-sensitive, although
+     *                   HTTP headers are generally not actually case-sensitive.
+     * @param valueRegex the pattern to be matched. Note that ".*" is useful for testing that a given header is
+     *                   actually absent.
+     * @return this
+     */
+    public StubMethod ifNotHeader(String key, String valueRegex) {
+        headerExpectations.put(key, new InverseHeaderExpectation(new RegexHeaderExpectation(valueRegex)));
+        return this;
+    }
+
+    /**
+     * Sets an expectation that requests will not be matched if they have a request header that matches
+     * a specified expression. To meet the expectation, the header must not match.
+     *
+     * @param key        the name of the header, e.g. "Content-Type". Note that this is case-sensitive, although
+     *                   HTTP headers are generally not actually case-sensitive.
+     * @param value the exact value to be matched.
+     * @return this
+     */
+    public StubMethod ifNotExactHeader(String key, String value) {
+        headerExpectations.put(key, new InverseHeaderExpectation(new LiteralHeaderExpectation(value)));
+        return this;
+    }
+
+    /**
      * Sets an expectation that requests will only be matched if they have a content-type that matches
      * a specified expression. This is a special case of {@link #ifHeader(String, String)}.
      *
@@ -251,7 +280,7 @@ public class StubMethod {
         b.append(' ').append(url);
         for (String key : headerExpectations.keySet()) {
             HeaderExpectation exp = headerExpectations.get(key);
-            b.append(" where ").append(key).append(" matches ").append(exp.getExpectedValue());
+            b.append(" where ").append(key).append(" must ").append(exp.getExpectedValue());
         }
         return b.toString();
     }


### PR DESCRIPTION
 It is now possible to assert that a header is absent or that a header does not match a given string or regular expression. :-)